### PR TITLE
Fix: Ensure fortune text is readable

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -352,6 +352,7 @@ select.form-control {
   animation: reveal 0.8s cubic-bezier(0.25, 1, 0.5, 1) forwards;
   transform: translateY(20px);
   opacity: 0;
+  color: var(--text);
 }
 
 @keyframes reveal {

--- a/src/css/redesign.css
+++ b/src/css/redesign.css
@@ -332,6 +332,7 @@ select.form-control {
   border-radius: var(--radius-md);
   margin-top: var(--space-lg);
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+  color: var(--text);
 }
 
 .fortune-content::before {


### PR DESCRIPTION
This commit fixes an issue where the text in the fortune content area could become unreadable due to a color conflict with the background.

The `color` property is now explicitly set on the `.fortune-content` class to ensure that the text inherits a readable color (`var(--text)`), regardless of the theme applied to the parent container.